### PR TITLE
Fix download queue bugs, add stop confirmation, clean up codebase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,9 @@ release/
 *.tmp
 *.temp
 repomix-output.xml
+.eslintcache
+.specstory
+.cursorindexingignore
 
 # Project notes
 notes.md

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -26,8 +26,6 @@ function createWindow(): void {
     }
   })
 
-  console.log('Window created with preload path:', join(__dirname, '../preload/index.js'))
-
   mainWindow.on('ready-to-show', () => {
     mainWindow.show()
     // Open DevTools in development
@@ -63,9 +61,6 @@ app.whenReady().then(() => {
   app.on('browser-window-created', (_, window) => {
     optimizer.watchWindowShortcuts(window)
   })
-
-  // IPC test
-  ipcMain.on('ping', () => console.log('pong'))
 
   // Register IPC handlers for electronAPI
   ipcMain.handle('select-directory', async () => {
@@ -112,19 +107,10 @@ app.whenReady().then(() => {
   })
 
   ipcMain.handle('export-data', async (_, options: { stable: boolean; lazer: boolean }) => {
-    console.log('Export data handler called with options:', options)
     try {
-      console.log('Calling exportService.exportData...')
-      const result = await exportService.exportData(options)
-      console.log('Export result:', result)
-      return result
+      return await exportService.exportData(options)
     } catch (error) {
-      console.error('Export failed with error:', error)
-      if (error instanceof Error) {
-        console.error('Error name:', error.name)
-        console.error('Error message:', error.message)
-        console.error('Error stack:', error.stack)
-      }
+      console.error('Export failed:', error)
       return {
         success: false,
         count: 0,

--- a/src/renderer/src/App.vue
+++ b/src/renderer/src/App.vue
@@ -146,7 +146,6 @@ onMounted(() => {
 </script>
 
 <style>
-@import url('https://fonts.googleapis.com/css2?family=Quicksand:wght@300..700&display=swap');
 .v-navigation-drawer {
   transition: width 0.2s ease-in-out !important;
   background: var(--v-theme-background) !important;

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -283,3 +283,14 @@ html, body, #app {
 .v-slider__label{
   opacity: 1 !important;
 }
+
+.text-success {
+  color: #4caf50;
+}
+.text-error {
+  color: #f44336;
+}
+
+.text-h6 {
+  font-family: var(--font-default) !important;
+}

--- a/src/renderer/src/components/Backup.vue
+++ b/src/renderer/src/components/Backup.vue
@@ -58,18 +58,10 @@ const isExporting = ref(false)
 const statusMessage = ref('')
 const isSuccess = ref(false)
 
-interface ExportError extends Error {
-  message: string
-}
-
 const handleExport = async (): Promise<void> => {
   if (!isButtonEnabled.value) return
 
   try {
-    console.log('Starting export with options:', {
-      stable: stableBackup.value,
-      lazer: lazerBackup.value
-    })
     isExporting.value = true
     statusMessage.value = ''
 
@@ -77,7 +69,6 @@ const handleExport = async (): Promise<void> => {
       stable: stableBackup.value,
       lazer: lazerBackup.value
     })
-    console.log('Export response:', response)
 
     if (!response?.success) {
       if (response?.error === 'cancelled') {
@@ -89,25 +80,13 @@ const handleExport = async (): Promise<void> => {
     isSuccess.value = true
     statusMessage.value = t('backup.success', { count: response.count })
   } catch (error: unknown) {
-    console.error('Export failed in component:', error)
     isSuccess.value = false
-    const exportError = error as ExportError
-    statusMessage.value =
-      exportError.message === 'cancelled'
-        ? t('backup.cancelled')
-        : exportError.message || t('backup.error')
+    const msg = error instanceof Error ? error.message : t('backup.error')
+    statusMessage.value = msg === 'cancelled' ? t('backup.cancelled') : msg
   } finally {
     isExporting.value = false
   }
 }
 </script>
 
-<style scoped>
-@import url('https://fonts.googleapis.com/css2?family=Quicksand:wght@300..700&display=swap');
-.text-success {
-  color: #4caf50;
-}
-.text-error {
-  color: #f44336;
-}
-</style>
+<style scoped></style>

--- a/src/renderer/src/components/Download.vue
+++ b/src/renderer/src/components/Download.vue
@@ -79,14 +79,33 @@
                 variant="text"
                 :title="isPaused ? $t('downloadManager.resume') : $t('downloadManager.pause')"
                 :lang="currentLocale"
+                :disabled="confirmingStop"
                 @click="togglePause"
               ></v-btn>
+              <template v-if="confirmingStop">
+                <v-btn
+                  icon="mdi-check"
+                  variant="text"
+                  color="error"
+                  :title="$t('downloadManager.stopConfirmYes')"
+                  :lang="currentLocale"
+                  @click="confirmStopDownload"
+                ></v-btn>
+                <v-btn
+                  icon="mdi-close"
+                  variant="text"
+                  :title="$t('downloadManager.stopConfirmNo')"
+                  :lang="currentLocale"
+                  @click="cancelStopDownload"
+                ></v-btn>
+              </template>
               <v-btn
+                v-else
                 icon="mdi-stop"
                 variant="text"
                 :title="$t('downloadManager.stop')"
                 :lang="currentLocale"
-                @click="stopDownload"
+                @click="requestStopDownload"
               ></v-btn>
             </div>
           </div>
@@ -172,10 +191,11 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
+import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { DefaultBeatmapMirrors } from '../../../config/beatmapMirrors'
 import { API_ENDPOINTS } from '../../../config/constants'
+import { useDownloadSettings } from '../composables/useDownloadSettings'
 
 const { locale, t } = useI18n()
 const currentLocale = computed(() => locale.value)
@@ -210,25 +230,31 @@ type QueueSummary = {
   durationMs?: number
 }
 
+// Download settings from composable
+const {
+  threadCount,
+  selectedSources,
+  removeFromStable,
+  removeFromLazer,
+  noVideo,
+  load: loadDownloadSettings
+} = useDownloadSettings()
+
 // Download Form State
 const selectedFile = ref<ElectronFile | null>(null)
 const selectedFileName = ref('')
-const threadCount = ref(5)
 const downloadPath = ref('')
 const isDownloading = ref(false)
 const statusMessage = ref('')
 const isSuccess = ref(false)
-const removeFromStable = ref(false)
-const removeFromLazer = ref(false)
-const noVideo = ref(false)
 
 // Load beatmap mirrors from backend
 const beatmapMirrors = ref(DefaultBeatmapMirrors)
-const selectedSources = ref<string[]>(DefaultBeatmapMirrors.map((source) => source.name))
 
 // Download Manager State
 const showDownloadManager = ref(false)
 const isPaused = ref(false)
+const confirmingStop = ref(false)
 const completedFiles = ref(0)
 const totalFiles = ref(0)
 const queueProgress = ref(0)
@@ -239,56 +265,23 @@ const completedSummary = ref<QueueSummary | null>(null)
 // SSE connection
 let eventSource: EventSource | null = null
 
-// Load mirror statuses
-// Save to localStorage
-const saveToLocalStorage = (): void => {
-  const settings = {
-    threadCount: threadCount.value,
-    selectedSources: selectedSources.value,
-    removeFromStable: removeFromStable.value,
-    removeFromLazer: removeFromLazer.value,
-    noVideo: noVideo.value
-  }
-  localStorage.setItem('downloadSettings', JSON.stringify(settings))
-}
-
-// Load from localStorage
-const loadFromLocalStorage = (): void => {
-  const savedSettings = localStorage.getItem('downloadSettings')
-  if (savedSettings) {
-    const settings = JSON.parse(savedSettings)
-    threadCount.value = settings.threadCount ?? 5
-    selectedSources.value = settings.selectedSources?.length
-      ? settings.selectedSources
-      : beatmapMirrors.value.map((source) => source.name)
-    removeFromStable.value = settings.removeFromStable || false
-    removeFromLazer.value = settings.removeFromLazer || false
-    noVideo.value = settings.noVideo || false
-  }
-}
-
 // Load settings
 const loadSettings = async (): Promise<void> => {
   try {
-    // Load beatmap mirrors from backend
     const res = await fetch(API_ENDPOINTS.SETTINGS)
     const data = await res.json()
 
-    // Update beatmap mirrors if available
     if (data.beatmapMirrors && Array.isArray(data.beatmapMirrors)) {
       beatmapMirrors.value = data.beatmapMirrors
     }
 
-    // Load download path from backend
     try {
       const downloadPathRes = await fetch(API_ENDPOINTS.SETTINGS_DOWNLOAD_PATH)
       const downloadPathData = await downloadPathRes.json()
       if (downloadPathData.downloadPath) {
         downloadPath.value = downloadPathData.downloadPath
-        // Validate the loaded path
         const validation = await validateDownloadPath(downloadPath.value)
         if (!validation.valid) {
-          // Clear invalid path and show warning
           downloadPath.value = ''
           await saveDownloadPath('')
           console.warn('Loaded download path is invalid:', validation.error)
@@ -298,19 +291,12 @@ const loadSettings = async (): Promise<void> => {
       console.error('Failed to load download path:', error)
     }
 
-    // Load download options from localStorage
-    loadFromLocalStorage()
+    loadDownloadSettings()
   } catch (error) {
     console.error('Failed to load settings:', error)
-    // If backend load fails, use default mirrors and localStorage settings
-    loadFromLocalStorage()
+    loadDownloadSettings()
   }
 }
-
-// Watch for changes and save to localStorage only
-watch([threadCount, selectedSources, removeFromStable, removeFromLazer, noVideo], () => {
-  saveToLocalStorage()
-})
 
 // Make sure settings are loaded when component is mounted
 onMounted(() => {
@@ -335,11 +321,7 @@ const handleFileSelect = async (): Promise<void> => {
     if (filePath) {
       const fileName = filePath.split(/[\\/]/).pop() || ''
       selectedFileName.value = fileName
-      selectedFile.value = {
-        name: fileName,
-        path: filePath
-      } as ElectronFile
-      console.log(`File selected: ${fileName}, path: ${filePath}`)
+      selectedFile.value = { name: fileName, path: filePath } as ElectronFile
     }
   } catch (error) {
     console.error('Failed to get file path:', error)
@@ -435,7 +417,6 @@ const handleDownload = async (): Promise<void> => {
       }
     }
 
-    // Prepare download data
     const downloadData = {
       filePath,
       options: {
@@ -447,13 +428,6 @@ const handleDownload = async (): Promise<void> => {
       },
       downloadPath: downloadPath.value || undefined
     }
-
-    console.log('Download request data:', {
-      filePath: downloadData.filePath,
-      threadCount: downloadData.options.threadCount,
-      selectedMirrors: downloadData.options.sources,
-      downloadPath: downloadData.downloadPath
-    })
 
     const response = await fetch(API_ENDPOINTS.DOWNLOAD, {
       method: 'POST',
@@ -475,15 +449,6 @@ const handleDownload = async (): Promise<void> => {
       }
       throw new Error(errorMessage)
     }
-
-    let result
-    try {
-      result = await response.json()
-    } catch (e) {
-      console.warn('Failed to parse response JSON:', e)
-      result = { success: true }
-    }
-    console.log('Download started:', result)
 
     isSuccess.value = true
     statusMessage.value = t('download.started')
@@ -586,7 +551,12 @@ const togglePause = async (): Promise<void> => {
   }
 }
 
-const stopDownload = async (): Promise<void> => {
+const requestStopDownload = (): void => {
+  confirmingStop.value = true
+}
+
+const confirmStopDownload = async (): Promise<void> => {
+  confirmingStop.value = false
   try {
     const response = await fetch(API_ENDPOINTS.DOWNLOAD_STOP, { method: 'POST' })
     if (!response.ok) {
@@ -595,6 +565,10 @@ const stopDownload = async (): Promise<void> => {
   } catch (error) {
     console.error('Failed to stop download:', error)
   }
+}
+
+const cancelStopDownload = (): void => {
+  confirmingStop.value = false
 }
 
 const openFolder = async (): Promise<void> => {
@@ -617,12 +591,8 @@ const openFolder = async (): Promise<void> => {
 
 // SSE setup
 const connectSSE = (): void => {
-  if (eventSource) {
-    console.log('SSE connection already exists')
-    return
-  }
+  if (eventSource) return
 
-  console.log('Creating new SSE connection')
   eventSource = new EventSource(API_ENDPOINTS.DOWNLOAD_EVENTS)
 
   eventSource.addEventListener('initialState', (e) => {
@@ -701,10 +671,31 @@ const connectSSE = (): void => {
   eventSource.addEventListener('queueCleared', () => {
     showDownloadManager.value = false
     isPaused.value = false
+    confirmingStop.value = false
     completedFiles.value = 0
     totalFiles.value = 0
     queueProgress.value = 0
     downloadFiles.value = []
+
+    const summary = completedSummary.value
+    if (summary) {
+      // Natural completion
+      isSuccess.value = summary.failed === 0
+      statusMessage.value =
+        summary.failed > 0
+          ? t('download.finishedWithErrors', {
+              success: summary.success,
+              total: summary.total,
+              failed: summary.failed
+            })
+          : t('download.finished', { success: summary.success })
+      completedSummary.value = null
+    } else {
+      // Stopped by user
+      isSuccess.value = false
+      statusMessage.value = t('download.cancelled')
+    }
+
     // Close SSE connection when queue is cleared
     disconnectSSE()
   })
@@ -738,7 +729,6 @@ const connectSSE = (): void => {
 
 const disconnectSSE = (): void => {
   if (eventSource) {
-    console.log('Closing SSE connection')
     eventSource.close()
     eventSource = null
   }
@@ -746,14 +736,6 @@ const disconnectSSE = (): void => {
 </script>
 
 <style scoped>
-@import url('https://fonts.googleapis.com/css2?family=Quicksand:wght@300..700&display=swap');
-.text-success {
-  color: #4caf50;
-}
-.text-error {
-  color: #f44336;
-}
-
 .view-container {
   position: relative;
   min-height: 100%;

--- a/src/renderer/src/components/Settings.vue
+++ b/src/renderer/src/components/Settings.vue
@@ -4,7 +4,7 @@
 
     <!-- General Settings Section -->
     <v-card class="view-card mb-4">
-      <v-card-title class="text-h6">General</v-card-title>
+      <v-card-title class="text-h6">{{ $t('settings.general') }}</v-card-title>
       <v-card-text>
         <v-form class="view-form">
           <v-text-field
@@ -71,7 +71,7 @@
 
     <!-- Download Settings Section -->
     <v-card class="view-card">
-      <v-card-title class="text-h6">Download</v-card-title>
+      <v-card-title class="text-h6">{{ $t('settings.download') }}</v-card-title>
       <v-card-text>
         <!-- Thread Count -->
         <div class="d-flex flex-column flex-sm-row align-sm-center mb-4">
@@ -148,8 +148,8 @@ import { ref, onMounted, computed, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { API_ENDPOINTS } from '../../../config/constants'
 import { languageNames, languageFlags } from '../i18n/languageProperties'
-import { DefaultBeatmapMirrors } from '../../../config/beatmapMirrors'
 import 'flag-icons/css/flag-icons.min.css'
+import { useDownloadSettings } from '../composables/useDownloadSettings'
 
 const { t, locale } = useI18n()
 
@@ -157,13 +157,15 @@ const { t, locale } = useI18n()
 const osuStablePath = ref('')
 const osuLazerPath = ref('')
 
-// Download Settings
-const threadCount = ref(5)
-const selectedSources = ref<string[]>(DefaultBeatmapMirrors.map((source) => source.name))
-const removeFromStable = ref(false)
-const removeFromLazer = ref(false)
-const noVideo = ref(false)
-const waitForDownloadsOnPause = ref(true)
+// Download settings from composable
+const {
+  threadCount,
+  removeFromStable,
+  removeFromLazer,
+  noVideo,
+  waitForDownloadsOnPause,
+  load: loadDownloadSettings
+} = useDownloadSettings()
 
 // Computed properties
 const availableLocales = computed(() =>
@@ -190,47 +192,15 @@ const threadCountLabel = computed(() => {
 const isStablePathValid = computed(() => !!osuStablePath.value)
 const isLazerPathValid = computed(() => !!osuLazerPath.value)
 
-// Save download settings to localStorage
-const saveDownloadSettings = (): void => {
-  const settings = {
-    threadCount: threadCount.value,
-    selectedSources: selectedSources.value,
-    removeFromStable: removeFromStable.value,
-    removeFromLazer: removeFromLazer.value,
-    noVideo: noVideo.value,
-    waitForDownloadsOnPause: waitForDownloadsOnPause.value
-  }
-  localStorage.setItem('downloadSettings', JSON.stringify(settings))
-}
-
-// Load download settings from localStorage
-const loadDownloadSettings = (): void => {
-  const savedSettings = localStorage.getItem('downloadSettings')
-  if (savedSettings) {
-    const settings = JSON.parse(savedSettings)
-    threadCount.value = settings.threadCount ?? 5
-    selectedSources.value = settings.selectedSources?.length
-      ? settings.selectedSources
-      : DefaultBeatmapMirrors.map((source) => source.name)
-    removeFromStable.value = settings.removeFromStable || false
-    removeFromLazer.value = settings.removeFromLazer || false
-    noVideo.value = settings.noVideo || false
-    waitForDownloadsOnPause.value = settings.waitForDownloadsOnPause ?? true
-  }
-}
-
 const loadSettings = async (): Promise<void> => {
   try {
     const res = await fetch(API_ENDPOINTS.SETTINGS)
     const data = await res.json()
     osuStablePath.value = data.osuStablePath || ''
     osuLazerPath.value = data.osuLazerPath || ''
-
-    // Load download options from localStorage
     loadDownloadSettings()
   } catch (error) {
     console.error('Failed to load settings:', error)
-    // If backend load fails, use default mirrors and localStorage settings
     loadDownloadSettings()
   }
 }
@@ -275,22 +245,7 @@ const selectOsuLazerPath = async (): Promise<void> => {
   }
 }
 
-// Watch for download settings changes and save to localStorage
-watch(
-  [
-    threadCount,
-    selectedSources,
-    removeFromStable,
-    removeFromLazer,
-    noVideo,
-    waitForDownloadsOnPause
-  ],
-  () => {
-    saveDownloadSettings()
-  }
-)
-
-// Watch waitForDownloadsOnPause and sync to backend
+// Sync waitForDownloadsOnPause to backend whenever it changes
 watch(waitForDownloadsOnPause, async (newValue) => {
   try {
     await fetch(API_ENDPOINTS.SETTINGS_WAIT_FOR_DOWNLOADS, {
@@ -305,12 +260,11 @@ watch(waitForDownloadsOnPause, async (newValue) => {
 
 onMounted(() => {
   loadSettings()
-  document.documentElement.lang = locale.value // Set initial lang attribute
+  document.documentElement.lang = locale.value
 })
 </script>
 
 <style scoped>
-@import url('https://fonts.googleapis.com/css2?family=Quicksand:wght@300..700&display=swap');
 .flag-icon {
   margin-right: 8px;
   font-size: 1.2em;
@@ -318,7 +272,5 @@ onMounted(() => {
 .v-divider {
   margin-bottom: 16px;
 }
-.text-h6 {
-  font-family: var(--font-default) !important;
-}
+
 </style>

--- a/src/renderer/src/composables/useDownloadSettings.ts
+++ b/src/renderer/src/composables/useDownloadSettings.ts
@@ -1,0 +1,77 @@
+import { ref, watch, type Ref } from 'vue'
+import { DefaultBeatmapMirrors } from '../../../config/beatmapMirrors'
+
+const STORAGE_KEY = 'downloadSettings'
+
+interface DownloadSettingsReturn {
+  threadCount: Ref<number>
+  selectedSources: Ref<string[]>
+  removeFromStable: Ref<boolean>
+  removeFromLazer: Ref<boolean>
+  noVideo: Ref<boolean>
+  waitForDownloadsOnPause: Ref<boolean>
+  load: () => void
+}
+
+export function useDownloadSettings(): DownloadSettingsReturn {
+  const threadCount = ref(5)
+  const selectedSources = ref<string[]>(DefaultBeatmapMirrors.map((s) => s.name))
+  const removeFromStable = ref(false)
+  const removeFromLazer = ref(false)
+  const noVideo = ref(false)
+  const waitForDownloadsOnPause = ref(true)
+
+  function save(): void {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        threadCount: threadCount.value,
+        selectedSources: selectedSources.value,
+        removeFromStable: removeFromStable.value,
+        removeFromLazer: removeFromLazer.value,
+        noVideo: noVideo.value,
+        waitForDownloadsOnPause: waitForDownloadsOnPause.value
+      })
+    )
+  }
+
+  function load(): void {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) return
+    try {
+      const s = JSON.parse(raw)
+      threadCount.value = s.threadCount ?? 5
+      selectedSources.value = s.selectedSources?.length
+        ? s.selectedSources
+        : DefaultBeatmapMirrors.map((src) => src.name)
+      removeFromStable.value = s.removeFromStable ?? false
+      removeFromLazer.value = s.removeFromLazer ?? false
+      noVideo.value = s.noVideo ?? false
+      waitForDownloadsOnPause.value = s.waitForDownloadsOnPause ?? true
+    } catch {
+      // Ignore malformed saved data
+    }
+  }
+
+  watch(
+    [
+      threadCount,
+      selectedSources,
+      removeFromStable,
+      removeFromLazer,
+      noVideo,
+      waitForDownloadsOnPause
+    ],
+    save
+  )
+
+  return {
+    threadCount,
+    selectedSources,
+    removeFromStable,
+    removeFromLazer,
+    noVideo,
+    waitForDownloadsOnPause,
+    load
+  }
+}

--- a/src/renderer/src/env.d.ts
+++ b/src/renderer/src/env.d.ts
@@ -15,7 +15,7 @@ interface ElectronAPI {
   selectDirectory: () => Promise<string>
   checkSubDir: (dir: string, sub: string) => Promise<boolean>
   checkFile: (dir: string, file: string) => Promise<boolean>
-  exportData: (options: { stable: boolean, lazer: boolean }) => Promise<void>
+  exportData: (options: { stable: boolean; lazer: boolean }) => Promise<void>
 }
 
 declare global {

--- a/src/renderer/src/i18n/index.ts
+++ b/src/renderer/src/i18n/index.ts
@@ -12,4 +12,4 @@ const i18n = createI18n({
   }
 })
 
-export default i18n 
+export default i18n

--- a/src/renderer/src/i18n/languageProperties.ts
+++ b/src/renderer/src/i18n/languageProperties.ts
@@ -1,13 +1,13 @@
 export const languageNames = {
   en: 'English',
-  vi: 'Tiếng Việt',
+  vi: 'Tiếng Việt'
   // Add new languages here
 } as const
 
 export const languageFlags = {
   en: 'gb',
-  vi: 'vn',
+  vi: 'vn'
   // Add new language flags here
 } as const
 
-export type LanguageCode = keyof typeof languageNames 
+export type LanguageCode = keyof typeof languageNames

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -1,5 +1,7 @@
 {
   "settings": {
+    "general": "General",
+    "download": "Download",
     "title": "Settings",
     "osuStablePath": "osu!stable directory",
     "osuLazerPath": "osu!lazer directory",
@@ -44,7 +46,8 @@
     },
     "button": "Download",
     "started": "Download started",
-    "success": "Successfully downloaded {count} beatmaps",
+    "finished": "Downloaded {success} beatmaps",
+    "finishedWithErrors": "Downloaded {success}/{total} beatmaps · {failed} failed",
     "error": "Download failed",
     "errors": {
       "invalidFile": "Invalid file type. Only .txt files are allowed.",
@@ -144,6 +147,8 @@
     "pause": "Pause Queue",
     "resume": "Resume Queue",
     "stop": "Stop Download",
+    "stopConfirmYes": "Confirm stop",
+    "stopConfirmNo": "Cancel",
     "table": {
       "status": "Status",
       "filename": "Filename",

--- a/src/renderer/src/i18n/locales/vi.json
+++ b/src/renderer/src/i18n/locales/vi.json
@@ -1,6 +1,8 @@
 {
   "settings": {
+    "general": "Tổng quan",
     "title": "Thiết lập",
+    "download": "Tải xuống",
     "osuStablePath": "Đường dẫn osu!stable",
     "osuLazerPath": "Đường dẫn osu!lazer",
     "selectFolder": "Chọn thư mục",
@@ -44,7 +46,8 @@
     },
     "button": "Tải xuống",
     "started": "Bắt đầu tải xuống",
-    "success": "Đã tải xuống thành công {count} beatmap",
+    "finished": "Đã tải {success} beatmap",
+    "finishedWithErrors": "Đã tải {success}/{total} beatmap · {failed} thất bại",
     "errors": {
       "invalidFile": "Định dạng file không hợp lệ. Chỉ cho phép file .txt",
       "getFilePath": "Không thể lấy đường dẫn file",
@@ -143,6 +146,8 @@
     "pause": "Tạm dừng",
     "resume": "Tiếp tục",
     "stop": "Dừng Tải xuống",
+    "stopConfirmYes": "Xác nhận dừng",
+    "stopConfirmNo": "Huỷ",
     "table": {
       "status": "Trạng thái",
       "filename": "Tên tệp",

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -17,6 +17,7 @@ import fs from 'fs'
 import path from 'path'
 import BeatmapMirrorService from './beatmapMirrorService'
 import DownloadService, { DownloadEvent, DownloadTask } from './downloadService'
+import { validateDownloadPath } from './download/fileUtils'
 
 const app = express()
 const port = 3000
@@ -151,26 +152,8 @@ app.get('/api/settings/validate/download-path', (async (
   }
 
   try {
-    // Check if path exists
-    if (!fs.existsSync(downloadPath)) {
-      res.json({ valid: false, error: 'Download path does not exist' })
-      return
-    }
-
-    // Check if path is a directory
-    const stats = await fs.promises.stat(downloadPath)
-    if (!stats.isDirectory()) {
-      res.json({ valid: false, error: 'Download path is not a directory' })
-      return
-    }
-
-    // Check write permission
-    try {
-      await fs.promises.access(downloadPath, fs.constants.W_OK)
-      res.json({ valid: true, error: null })
-    } catch {
-      res.json({ valid: false, error: 'No write permission in download path' })
-    }
+    await validateDownloadPath(downloadPath)
+    res.json({ valid: true, error: null })
   } catch (error) {
     res.json({
       valid: false,

--- a/src/services/download/fileUtils.ts
+++ b/src/services/download/fileUtils.ts
@@ -1,0 +1,115 @@
+import path from 'path'
+import fs from 'fs'
+import os from 'os'
+import { execSync } from 'child_process'
+import { getOsuStablePath } from '../settingsStore'
+import { realmService } from '../realmService'
+import type { DownloadOptions } from './types'
+
+export function getDefaultDownloadPath(): string {
+  const platform = process.platform
+  const homeDir = os.homedir()
+
+  switch (platform) {
+    case 'win32':
+      try {
+        const command =
+          'reg query "HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\User Shell Folders" /v "{374DE290-123F-4565-9164-39C4925E467B}"'
+        const output = execSync(command, { encoding: 'utf-8' })
+        const match = output.match(/REG_EXPAND_SZ\s+(.+)$/)
+        if (match) {
+          return match[1].replace(/%([^%]+)%/g, (_, n) => process.env[n] || '')
+        }
+      } catch {
+        // Fall through to default
+      }
+      return path.join(homeDir, 'Downloads')
+    default:
+      return path.join(homeDir, 'Downloads')
+  }
+}
+
+export async function validateDownloadPath(downloadPath: string): Promise<void> {
+  if (!fs.existsSync(downloadPath)) {
+    throw new Error('Download path does not exist')
+  }
+
+  const stats = await fs.promises.stat(downloadPath)
+  if (!stats.isDirectory()) {
+    throw new Error('Download path is not a directory')
+  }
+
+  try {
+    await fs.promises.access(downloadPath, fs.constants.W_OK)
+  } catch {
+    throw new Error('No write permission in download path')
+  }
+}
+
+export function validateBackupFile(content: string): void {
+  if (!content.startsWith('# Beatmap Backup File')) {
+    throw new Error('Invalid backup file format: Missing header')
+  }
+
+  const requiredMetadata = [
+    '# Format: One beatmapset ID per line',
+    '# Created:',
+    '# Total beatmaps:',
+    '# Source:'
+  ]
+
+  for (const metadata of requiredMetadata) {
+    if (!content.includes(metadata)) {
+      throw new Error(`Invalid backup file format: Missing ${metadata}`)
+    }
+  }
+
+  const lines = content.split('\n')
+  const ids = lines.filter((line) => line.trim() && !line.startsWith('#'))
+
+  if (ids.length === 0) {
+    throw new Error('Invalid backup file: No beatmapset IDs found')
+  }
+
+  for (const id of ids) {
+    if (!/^\d+$/.test(id.trim())) {
+      throw new Error(`Invalid beatmapset ID: ${id}`)
+    }
+  }
+}
+
+export async function getExistingBeatmapsetIds(options: DownloadOptions): Promise<Set<number>> {
+  const existingIds = new Set<number>()
+
+  if (options.removeFromStable) {
+    try {
+      const osuStablePath = getOsuStablePath()
+      if (osuStablePath) {
+        const songsPath = path.join(osuStablePath, 'Songs')
+        if (fs.existsSync(songsPath)) {
+          const folders = fs.readdirSync(songsPath)
+          for (const folder of folders) {
+            const match = folder.match(/^(\d+)\s/)
+            if (match) {
+              const id = parseInt(match[1])
+              if (!isNaN(id)) existingIds.add(id)
+            }
+          }
+        }
+      }
+    } catch (error) {
+      console.warn('Failed to get stable beatmapset IDs:', error)
+    }
+  }
+
+  if (options.removeFromLazer) {
+    try {
+      const lazerIds = await realmService.getBeatmapsetIds()
+      lazerIds.forEach((id) => existingIds.add(id))
+    } catch (error) {
+      console.warn('Failed to get lazer beatmapset IDs:', error)
+    }
+  }
+
+  return existingIds
+}

--- a/src/services/download/httpDownloader.ts
+++ b/src/services/download/httpDownloader.ts
@@ -1,0 +1,172 @@
+import path from 'path'
+import fs from 'fs'
+import https from 'https'
+import http from 'http'
+import { URL } from 'url'
+import type { DownloadTask } from './types'
+
+export interface MirrorHealth {
+  success: number
+  failure: number
+  avgResponseTime: number
+}
+
+function sanitizeFileName(name: string): string {
+  const invalidChars = /[<>:\\"/|?*]/g
+  let safe = name.replace(invalidChars, ' ').replace(/\s+/g, ' ').trim()
+  // Disallow trailing periods or spaces on Windows
+  safe = safe.replace(/[ .]+$/g, '')
+  if (!/\.osz$/i.test(safe)) {
+    safe = `${safe}.osz`
+  }
+  return safe
+}
+
+export async function downloadFile(
+  task: DownloadTask,
+  downloadPath: string,
+  onProgress: (task: DownloadTask) => void
+): Promise<{ startTime: number }> {
+  // If a drive root like "F:\\" is passed, use a safe subfolder
+  const resolvedForCheck = path.resolve(downloadPath)
+  if (resolvedForCheck === path.parse(resolvedForCheck).root) {
+    downloadPath = path.join(downloadPath, 'osu-beatmaps')
+  }
+
+  // Create download directory if it doesn't exist (avoid creating drive root)
+  const resolvedPath = path.resolve(downloadPath)
+  const isRoot = resolvedPath === path.parse(resolvedPath).root
+  if (!isRoot) {
+    try {
+      await fs.promises.mkdir(downloadPath, { recursive: true })
+    } catch (e) {
+      if (!(e instanceof Error) || (e as NodeJS.ErrnoException).code !== 'EEXIST') {
+        throw e
+      }
+    }
+  }
+
+  const downloadUrl = task.mirror.getDownloadUrl(task.beatmapsetId, task.noVideo)
+
+  return new Promise<{ startTime: number }>((resolve, reject) => {
+    const startUrl = new URL(downloadUrl)
+    const startTime = Date.now()
+    let writer: fs.WriteStream | undefined
+    let filePath: string | undefined
+    let currentResponse: http.IncomingMessage | undefined
+
+    const makeRequest = (targetUrl: URL, redirectCount = 0): void => {
+      const protocol = targetUrl.protocol === 'http:' ? http : https
+      const req = protocol.request(
+        targetUrl,
+        {
+          headers: {
+            'User-Agent': 'osu-beatmap-backup/1.0 (+https://github.com)'
+          }
+        },
+        (response) => {
+          currentResponse = response
+          // Handle redirects
+          if (
+            response.statusCode &&
+            response.statusCode >= 300 &&
+            response.statusCode < 400 &&
+            response.headers.location
+          ) {
+            if (redirectCount >= 5) {
+              reject(new Error('Too many redirects'))
+              return
+            }
+            try {
+              const nextUrl = new URL(response.headers.location, targetUrl)
+              req.destroy()
+              makeRequest(nextUrl, redirectCount + 1)
+              return
+            } catch {
+              reject(new Error('Invalid redirect URL'))
+              return
+            }
+          }
+
+          if (response.statusCode !== 200) {
+            reject(new Error(`Failed to download: ${response.statusCode}`))
+            return
+          }
+
+          const totalSize = parseInt(response.headers['content-length'] || '0', 10)
+
+          // Get filename from Content-Disposition header or fallback to beatmapsetId
+          let fileName = `${task.beatmapsetId}.osz`
+          const contentDisposition = response.headers['content-disposition']
+          if (contentDisposition) {
+            const matches = /filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/.exec(contentDisposition)
+            if (matches && matches[1]) {
+              fileName = matches[1].replace(/['"]/g, '')
+            }
+          }
+          fileName = sanitizeFileName(fileName)
+          filePath = path.join(downloadPath, fileName)
+
+          task.fileName = fileName
+          onProgress(task)
+
+          writer = fs.createWriteStream(filePath)
+          let downloadedBytes = 0
+          let lastUpdate = startTime
+          let lastBytes = 0
+
+          response.on('data', (chunk) => {
+            downloadedBytes += chunk.length
+            const currentTime = Date.now()
+            const timeDiff = (currentTime - lastUpdate) / 1000
+            const bytesDiff = downloadedBytes - lastBytes
+
+            if (timeDiff >= 1) {
+              task.speed = bytesDiff / timeDiff
+              task.progress = totalSize ? Math.round((downloadedBytes / totalSize) * 100) : 0
+              task.remainingTime = totalSize
+                ? Math.round((totalSize - downloadedBytes) / task.speed)
+                : 0
+              onProgress(task)
+              lastUpdate = currentTime
+              lastBytes = downloadedBytes
+            }
+          })
+
+          response.on('error', (err) => reject(err))
+          writer.on('error', (err) => reject(err))
+
+          response.pipe(writer)
+
+          writer.on('finish', () => {
+            task.status = 'completed'
+            task.progress = 100
+            task.speed = 0
+            task.remainingTime = 0
+            task.filePath = filePath
+            resolve({ startTime })
+          })
+        }
+      )
+
+      req.on('error', (error) => {
+        currentResponse?.destroy()
+        writer?.destroy()
+        if (filePath) {
+          fs.unlink(filePath, () => {})
+        }
+        reject(error)
+      })
+
+      req.setTimeout(30000, () => {
+        req.destroy(new Error('Request timeout'))
+      })
+
+      req.end()
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ;(task as any).request = req
+    }
+
+    makeRequest(startUrl)
+  })
+}

--- a/src/services/download/types.ts
+++ b/src/services/download/types.ts
@@ -1,0 +1,40 @@
+import type { BeatmapMirror } from '../../config/beatmapMirrors'
+import type https from 'https'
+
+export interface DownloadTask {
+  id: string
+  beatmapsetId: string
+  mirror: BeatmapMirror
+  noVideo: boolean
+  status: 'waiting' | 'downloading' | 'completed' | 'error'
+  progress: number
+  speed: number
+  remainingTime: number
+  error?: string
+  /** Directory chosen by user (or default OS Downloads) */
+  downloadPath?: string
+  /** Final file name and full path, set once headers are known / completed */
+  fileName?: string
+  filePath?: string
+  request?: ReturnType<typeof https.get>
+}
+
+export interface DownloadOptions {
+  threadCount: number
+  sources: string[]
+  noVideo: boolean
+  downloadPath?: string
+  removeFromStable: boolean
+  removeFromLazer: boolean
+}
+
+export enum DownloadEvent {
+  TASK_ADDED = 'taskAdded',
+  TASK_UPDATED = 'taskUpdated',
+  TASK_COMPLETED = 'taskCompleted',
+  TASK_ERROR = 'taskError',
+  QUEUE_PAUSED = 'queuePaused',
+  QUEUE_RESUMED = 'queueResumed',
+  QUEUE_CLEARED = 'queueCleared',
+  QUEUE_COMPLETED = 'queueCompleted'
+}

--- a/src/services/downloadService.ts
+++ b/src/services/downloadService.ts
@@ -1,62 +1,20 @@
 import { EventEmitter } from 'events'
-// import { default as PQueue } from 'p-queue'
-import path from 'path'
+import { BeatmapMirror, DefaultBeatmapMirrors } from '../config/beatmapMirrors'
+import { DownloadTask, DownloadOptions, DownloadEvent } from './download/types'
+import {
+  getDefaultDownloadPath,
+  validateDownloadPath,
+  validateBackupFile,
+  getExistingBeatmapsetIds
+} from './download/fileUtils'
+import { downloadFile, MirrorHealth } from './download/httpDownloader'
 import fs from 'fs'
-import https from 'https'
-import http from 'http'
-import { URL } from 'url'
-import { BeatmapMirror } from '../config/beatmapMirrors'
-import { DefaultBeatmapMirrors } from '../config/beatmapMirrors'
-import os from 'os'
-import { execSync } from 'child_process'
-import { getOsuStablePath } from './settingsStore'
-import { realmService } from './realmService'
+
+export type { DownloadTask, DownloadOptions }
+export { DownloadEvent }
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const PQueue = require('p-queue').default
-console.log('PQueue in downloadService:', PQueue)
-console.log('PQueue type:', typeof PQueue)
-console.log('PQueue prototype:', PQueue.prototype)
-
-// Types
-export interface DownloadTask {
-  id: string
-  beatmapsetId: string
-  mirror: BeatmapMirror
-  noVideo: boolean
-  status: 'waiting' | 'downloading' | 'completed' | 'error'
-  progress: number
-  speed: number
-  remainingTime: number
-  error?: string
-  // Directory chosen by user (or default OS Downloads)
-  downloadPath?: string
-  // Final file name and full path, set once headers are known / completed
-  fileName?: string
-  filePath?: string
-  request?: ReturnType<typeof https.get>
-}
-
-export interface DownloadOptions {
-  threadCount: number
-  sources: string[]
-  noVideo: boolean
-  downloadPath?: string
-  removeFromStable: boolean
-  removeFromLazer: boolean
-}
-
-// Events
-export enum DownloadEvent {
-  TASK_ADDED = 'taskAdded',
-  TASK_UPDATED = 'taskUpdated',
-  TASK_COMPLETED = 'taskCompleted',
-  TASK_ERROR = 'taskError',
-  QUEUE_PAUSED = 'queuePaused',
-  QUEUE_RESUMED = 'queueResumed',
-  QUEUE_CLEARED = 'queueCleared',
-  QUEUE_COMPLETED = 'queueCompleted'
-}
 
 class DownloadService extends EventEmitter {
   private static instance: DownloadService
@@ -65,8 +23,11 @@ class DownloadService extends EventEmitter {
   private isPaused: boolean
   private cooldownPeriod: number
   private cooldownTimeout?: NodeJS.Timeout
-  private mirrorHealth: Map<string, { success: number; failure: number; avgResponseTime: number }>
+  private mirrorHealth: Map<string, MirrorHealth>
   private queueStartTime: number | null
+  /** Stored so resumeQueue can re-add waiting tasks without needing closure args */
+  private currentMirrors: BeatmapMirror[] = []
+  private currentOptions: DownloadOptions | null = null
 
   private constructor() {
     super()
@@ -85,178 +46,33 @@ class DownloadService extends EventEmitter {
     return DownloadService.instance
   }
 
-  private getDefaultDownloadPath(): string {
-    const platform = process.platform
-    const homeDir = os.homedir()
-
-    switch (platform) {
-      case 'win32':
-        try {
-          // Read registry to get Downloads folder location
-          const command =
-            'reg query "HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\User Shell Folders" /v "{374DE290-123F-4565-9164-39C4925E467B}"'
-          const output = execSync(command, { encoding: 'utf-8' })
-          const match = output.match(/REG_EXPAND_SZ\s+(.+)$/)
-
-          if (match) {
-            // Expand environment variables in the path
-            const expandedPath = match[1].replace(/%([^%]+)%/g, (_, n) => process.env[n] || '')
-            return expandedPath
-          }
-        } catch (error) {
-          console.warn('Failed to read registry for Downloads folder:', error)
-        }
-        // Fallback to default Downloads folder
-        return path.join(homeDir, 'Downloads')
-      case 'darwin':
-        return path.join(homeDir, 'Downloads')
-      case 'linux':
-        return path.join(homeDir, 'Downloads')
-      default:
-        return path.join(homeDir, 'Downloads')
-    }
-  }
-
-  private async getExistingBeatmapsetIds(options: DownloadOptions): Promise<Set<number>> {
-    const existingIds = new Set<number>()
-
-    if (options.removeFromStable) {
-      try {
-        const osuStablePath = getOsuStablePath()
-        if (osuStablePath) {
-          const songsPath = path.join(osuStablePath, 'Songs')
-          if (fs.existsSync(songsPath)) {
-            const folders = fs.readdirSync(songsPath)
-            for (const folder of folders) {
-              const match = folder.match(/^(\d+)\s/)
-              if (match) {
-                const id = parseInt(match[1])
-                if (!isNaN(id)) {
-                  existingIds.add(id)
-                }
-              }
-            }
-            console.log('Found', existingIds.size, 'existing stable beatmapset IDs')
-          }
-        }
-      } catch (error) {
-        console.warn('Failed to get stable beatmapset IDs:', error)
-      }
-    }
-
-    if (options.removeFromLazer) {
-      try {
-        const lazerIds = await realmService.getBeatmapsetIds()
-        lazerIds.forEach((id) => existingIds.add(id))
-        console.log('Found', lazerIds.length, 'existing lazer beatmapset IDs')
-      } catch (error) {
-        console.warn('Failed to get lazer beatmapset IDs:', error)
-      }
-    }
-
-    return existingIds
-  }
-
-  private validateBackupFile(content: string): void {
-    // Check if file has header
-    if (!content.startsWith('# Beatmap Backup File')) {
-      throw new Error('Invalid backup file format: Missing header')
-    }
-
-    // Check if file has required metadata
-    const requiredMetadata = [
-      '# Format: One beatmapset ID per line',
-      '# Created:',
-      '# Total beatmaps:',
-      '# Source:'
-    ]
-
-    for (const metadata of requiredMetadata) {
-      if (!content.includes(metadata)) {
-        throw new Error(`Invalid backup file format: Missing ${metadata}`)
-      }
-    }
-
-    // Get beatmapset IDs (skip header)
-    const lines = content.split('\n')
-    const ids = lines.filter((line) => line.trim() && !line.startsWith('#'))
-
-    if (ids.length === 0) {
-      throw new Error('Invalid backup file: No beatmapset IDs found')
-    }
-
-    // Validate each ID
-    for (const id of ids) {
-      if (!/^\d+$/.test(id.trim())) {
-        throw new Error(`Invalid beatmapset ID: ${id}`)
-      }
-    }
-  }
-
-  private async validateDownloadPath(downloadPath: string): Promise<void> {
-    try {
-      // Check if path exists
-      if (!fs.existsSync(downloadPath)) {
-        throw new Error('Download path does not exist')
-      }
-
-      // Check if path is a directory
-      const stats = await fs.promises.stat(downloadPath)
-      if (!stats.isDirectory()) {
-        throw new Error('Download path is not a directory')
-      }
-
-      // Check write permission
-      try {
-        await fs.promises.access(downloadPath, fs.constants.W_OK)
-      } catch {
-        throw new Error('No write permission in download path')
-      }
-    } catch (error) {
-      if (error instanceof Error) {
-        throw new Error(`Download path validation failed: ${error.message}`)
-      }
-      throw error
-    }
-  }
-
   public async startDownload(filePath: string, options: DownloadOptions): Promise<void> {
     try {
       this.queueStartTime = Date.now()
-      // Read and validate backup file
+
       const content = await fs.promises.readFile(filePath, 'utf-8')
-      this.validateBackupFile(content)
+      validateBackupFile(content)
       const beatmapsetIds = content
         .split('\n')
         .filter((line) => line.trim() && !line.startsWith('#'))
         .map((id) => id.trim())
 
-      // Get existing beatmapset IDs if ignore options are enabled
       let existingIds = new Set<number>()
       if (options.removeFromStable || options.removeFromLazer) {
-        existingIds = await this.getExistingBeatmapsetIds(options)
-        console.log('Found', existingIds.size, 'existing beatmapset IDs to ignore')
+        existingIds = await getExistingBeatmapsetIds(options)
       }
 
-      // Filter out existing beatmaps
       const filteredIds = beatmapsetIds.filter((id) => {
         const numericId = parseInt(id)
         return !isNaN(numericId) && !existingIds.has(numericId)
       })
 
-      console.log('Original beatmapset IDs:', beatmapsetIds.length)
-      console.log('After filtering existing:', filteredIds.length)
-      console.log('Ignored existing:', beatmapsetIds.length - filteredIds.length)
-
       if (filteredIds.length === 0) {
-        console.log('All beatmaps already exist, no download needed')
         return
       }
 
-      // Update queue concurrency
       this.queue.concurrency = options.threadCount
 
-      // Get available mirrors
       const availableMirrors = DefaultBeatmapMirrors.filter((mirror) =>
         options.sources.includes(mirror.name)
       )
@@ -265,13 +81,12 @@ class DownloadService extends EventEmitter {
         throw new Error('No available mirrors selected')
       }
 
-      // Use default download path if not specified
-      const downloadPath = options.downloadPath || this.getDefaultDownloadPath()
+      const dlPath = options.downloadPath || getDefaultDownloadPath()
+      await validateDownloadPath(dlPath)
 
-      // Validate download path
-      await this.validateDownloadPath(downloadPath)
+      this.currentMirrors = availableMirrors
+      this.currentOptions = options
 
-      // Add tasks to queue
       for (const beatmapsetId of filteredIds) {
         const task: DownloadTask = {
           id: `${beatmapsetId}-${Date.now()}`,
@@ -282,17 +97,14 @@ class DownloadService extends EventEmitter {
           progress: 0,
           speed: 0,
           remainingTime: 0,
-          downloadPath
+          downloadPath: dlPath
         }
 
         this.tasks.set(task.id, task)
         this.emit(DownloadEvent.TASK_ADDED, task)
-
         this.queue.add(() => this.downloadTask(task, availableMirrors, options))
       }
 
-      // When the queue becomes idle (no pending/active tasks), verify completion
-      // This covers timing where individual task callbacks resolve before PQueue updates counters
       this.queue.onIdle().then(() => {
         this.checkQueueCompletion()
       })
@@ -303,7 +115,6 @@ class DownloadService extends EventEmitter {
   }
 
   private checkQueueCompletion(): void {
-    // Not completed if there are active tasks, pending queue, or cooldown scheduled
     const hasActive = Array.from(this.tasks.values()).some(
       (t) => t.status !== 'completed' && t.status !== 'error'
     )
@@ -315,24 +126,23 @@ class DownloadService extends EventEmitter {
     const success = Array.from(this.tasks.values()).filter((t) => t.status === 'completed').length
     const failed = Array.from(this.tasks.values()).filter((t) => t.status === 'error').length
     const anyTask = this.tasks.values().next().value as DownloadTask | undefined
-    const downloadPath = anyTask?.downloadPath ?? null
+    const dlPath = anyTask?.downloadPath ?? null
     const durationMs = this.queueStartTime ? Date.now() - this.queueStartTime : 0
 
     this.emit(DownloadEvent.QUEUE_COMPLETED, {
       total,
       success,
       failed,
-      downloadPath,
+      downloadPath: dlPath,
       durationMs
     })
 
-    // Auto clear queue after short delay to let UI display completion
     setTimeout(() => this.clearQueue(), 2000)
   }
 
   private async downloadTask(
     task: DownloadTask,
-    availableMirrors: BeatmapMirror[],
+    availableMirrors: typeof DefaultBeatmapMirrors,
     options: DownloadOptions
   ): Promise<void> {
     if (this.isPaused) {
@@ -344,187 +154,27 @@ class DownloadService extends EventEmitter {
     task.status = 'downloading'
     this.emit(DownloadEvent.TASK_UPDATED, task)
 
+    const taskDownloadPath = task.downloadPath || options.downloadPath || getDefaultDownloadPath()
+
     try {
-      const downloadUrl = task.mirror.getDownloadUrl(task.beatmapsetId, task.noVideo)
-      // Prefer validated path stored on task, then provided option, then OS default
-      let downloadPath = task.downloadPath || options.downloadPath || this.getDefaultDownloadPath()
-      // If a drive root like "F:\\" is passed, default to a safe subfolder
-      const resolvedForCheck = path.resolve(downloadPath)
-      if (resolvedForCheck === path.parse(resolvedForCheck).root) {
-        downloadPath = path.join(downloadPath, 'osu-beatmaps')
-      }
-
-      // Create download directory if it doesn't exist (avoid creating drive root)
-      const resolvedPath = path.resolve(downloadPath)
-      const isRoot = resolvedPath === path.parse(resolvedPath).root
-      if (!isRoot) {
-        try {
-          await fs.promises.mkdir(downloadPath, { recursive: true })
-        } catch (e) {
-          // Ignore EEXIST; rethrow others
-          if (!(e instanceof Error) || (e as NodeJS.ErrnoException).code !== 'EEXIST') {
-            throw e
-          }
-        }
-      }
-
-      // Start download
-      await new Promise<void>((resolve, reject) => {
-        const startUrl = new URL(downloadUrl)
-        let writer: fs.WriteStream | undefined
-        let filePath: string | undefined
-
-        // Sanitize file names for the current OS and ensure .osz extension
-        const sanitizeFileName = (name: string): string => {
-          const invalidChars = /[<>:\\"/|?*]/g
-          let safe = name.replace(invalidChars, ' ').replace(/\s+/g, ' ').trim()
-          // Disallow trailing periods or spaces on Windows
-          safe = safe.replace(/[ .]+$/g, '')
-          if (!/\.osz$/i.test(safe)) {
-            safe = `${safe}.osz`
-          }
-          return safe
-        }
-
-        const makeRequest = (targetUrl: URL, redirectCount = 0): void => {
-          const protocol = targetUrl.protocol === 'http:' ? http : https
-          const req = protocol.request(
-            targetUrl,
-            {
-              headers: {
-                'User-Agent': 'osu-beatmap-backup/1.0 (+https://github.com)'
-              }
-            },
-            (response) => {
-              // Handle redirects
-              if (
-                response.statusCode &&
-                response.statusCode >= 300 &&
-                response.statusCode < 400 &&
-                response.headers.location
-              ) {
-                if (redirectCount >= 5) {
-                  reject(new Error('Too many redirects'))
-                  return
-                }
-                try {
-                  const nextUrl = new URL(response.headers.location, targetUrl)
-                  req.destroy()
-                  makeRequest(nextUrl, redirectCount + 1)
-                  return
-                } catch {
-                  reject(new Error('Invalid redirect URL'))
-                  return
-                }
-              }
-
-              if (response.statusCode !== 200) {
-                reject(new Error(`Failed to download: ${response.statusCode}`))
-                return
-              }
-
-              const totalSize = parseInt(response.headers['content-length'] || '0', 10)
-
-              // Get filename from Content-Disposition header or fallback to beatmapsetId
-              let fileName = `${task.beatmapsetId}.osz`
-              const contentDisposition = response.headers['content-disposition']
-              if (contentDisposition) {
-                const matches = /filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/.exec(contentDisposition)
-                if (matches && matches[1]) {
-                  fileName = matches[1].replace(/['"]/g, '')
-                }
-              }
-              fileName = sanitizeFileName(fileName)
-              filePath = path.join(downloadPath, fileName)
-
-              // Update task with discovered file name
-              task.fileName = fileName
-              this.emit(DownloadEvent.TASK_UPDATED, task)
-
-              // Create write stream
-              writer = fs.createWriteStream(filePath)
-              let downloadedBytes = 0
-              const startTime = Date.now()
-              let lastUpdate = startTime
-              let lastBytes = 0
-
-              response.on('data', (chunk) => {
-                downloadedBytes += chunk.length
-                const currentTime = Date.now()
-                const timeDiff = (currentTime - lastUpdate) / 1000
-                const bytesDiff = downloadedBytes - lastBytes
-
-                if (timeDiff >= 1) {
-                  task.speed = bytesDiff / timeDiff
-                  task.progress = totalSize ? Math.round((downloadedBytes / totalSize) * 100) : 0
-                  task.remainingTime = totalSize
-                    ? Math.round((totalSize - downloadedBytes) / task.speed)
-                    : 0
-                  this.emit(DownloadEvent.TASK_UPDATED, task)
-                  lastUpdate = currentTime
-                  lastBytes = downloadedBytes
-                }
-              })
-
-              response.on('error', (err) => reject(err))
-              writer.on('error', (err) => reject(err))
-
-              response.pipe(writer)
-
-              writer.on('finish', () => {
-                // Update mirror health on success
-                const mirrorName = task.mirror.name
-                const health = this.mirrorHealth.get(mirrorName) || {
-                  success: 0,
-                  failure: 0,
-                  avgResponseTime: 0
-                }
-                health.success++
-                health.avgResponseTime =
-                  (health.avgResponseTime * (health.success - 1) + (Date.now() - startTime)) /
-                  health.success
-                this.mirrorHealth.set(mirrorName, health)
-
-                task.status = 'completed'
-                task.progress = 100
-                task.speed = 0
-                task.remainingTime = 0
-                task.filePath = filePath
-                this.emit(DownloadEvent.TASK_COMPLETED, task)
-                resolve()
-                // Evaluate queue completion after each task finishes
-                this.checkQueueCompletion()
-              })
-            }
-          )
-
-          req.on('error', (error) => {
-            try {
-              if (writer) {
-                writer.close()
-              }
-            } catch {
-              /* empty */
-            }
-            if (filePath) {
-              fs.unlink(filePath, () => {})
-            }
-            reject(error)
-          })
-
-          // 30s timeout
-          req.setTimeout(30000, () => {
-            req.destroy(new Error('Request timeout'))
-          })
-
-          req.end()
-          // Track request for possible cancellation
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          ;(task as any).request = req
-        }
-
-        makeRequest(startUrl)
+      const { startTime } = await downloadFile(task, taskDownloadPath, (updatedTask) => {
+        this.emit(DownloadEvent.TASK_UPDATED, updatedTask)
       })
+
+      // Update mirror health on success
+      const mirrorName = task.mirror.name
+      const health = this.mirrorHealth.get(mirrorName) || {
+        success: 0,
+        failure: 0,
+        avgResponseTime: 0
+      }
+      health.success++
+      health.avgResponseTime =
+        (health.avgResponseTime * (health.success - 1) + (Date.now() - startTime)) / health.success
+      this.mirrorHealth.set(mirrorName, health)
+
+      this.emit(DownloadEvent.TASK_COMPLETED, task)
+      this.checkQueueCompletion()
     } catch (error) {
       console.error(`Download failed for ${task.beatmapsetId}:`, error)
 
@@ -538,20 +188,22 @@ class DownloadService extends EventEmitter {
       health.failure++
       this.mirrorHealth.set(mirrorName, health)
 
-      // If error is due to abort, don't try next mirror
       if (error instanceof Error && error.message === 'Download aborted') {
         task.status = 'waiting'
         task.error = 'Download cancelled'
         this.emit(DownloadEvent.TASK_UPDATED, task)
+        // Race condition guard: if resumeQueue() ran before this abort settled,
+        // re-add the task now since resumeQueue already iterated past it.
+        if (!this.isPaused && this.currentMirrors.length && this.currentOptions) {
+          this.queue.add(() => this.downloadTask(task, this.currentMirrors, this.currentOptions!))
+        }
         return
       }
 
-      // Try next mirror
       const currentIndex = availableMirrors.indexOf(task.mirror)
       const nextIndex = (currentIndex + 1) % availableMirrors.length
 
       if (nextIndex === 0) {
-        // All mirrors failed, enter cooldown
         task.status = 'error'
         task.error = error instanceof Error ? error.message : 'Download failed'
         this.emit(DownloadEvent.TASK_ERROR, task)
@@ -559,23 +211,21 @@ class DownloadService extends EventEmitter {
         if (!this.cooldownTimeout) {
           this.cooldownTimeout = setTimeout(() => {
             this.cooldownTimeout = undefined
-            // Retry failed tasks
-            for (const [, task] of this.tasks) {
-              if (task.status === 'error') {
-                task.status = 'waiting'
-                task.mirror = availableMirrors[0]
-                this.emit(DownloadEvent.TASK_UPDATED, task)
-                this.queue.add(() => this.downloadTask(task, availableMirrors, options))
+            for (const [, t] of this.tasks) {
+              if (t.status === 'error') {
+                t.status = 'waiting'
+                t.mirror = availableMirrors[0]
+                this.emit(DownloadEvent.TASK_UPDATED, t)
+                this.queue.add(() => this.downloadTask(t, availableMirrors, options))
               }
             }
           }, this.cooldownPeriod)
         }
-        // If we are not retrying immediately, check if queue is now completed
+
         if (this.queue.size === 0 && this.queue.pending === 0) {
           this.checkQueueCompletion()
         }
       } else {
-        // Try next mirror
         task.mirror = availableMirrors[nextIndex]
         task.status = 'waiting'
         this.emit(DownloadEvent.TASK_UPDATED, task)
@@ -588,33 +238,48 @@ class DownloadService extends EventEmitter {
     const { getWaitForDownloadsOnPause } = await import('./settingsStore')
     const shouldWaitForCompletion = getWaitForDownloadsOnPause()
 
-    const activeDownloads = Array.from(this.tasks.values()).filter(
-      (task) => task.status === 'downloading'
-    )
+    this.isPaused = true
+    // Clear queued-but-not-started tasks from PQueue so they don't drain
+    // through downloadTask (hitting the isPaused check and exiting) while paused.
+    // They remain in this.tasks with status 'waiting' and will be re-added on resume.
+    this.queue.clear()
 
-    if (activeDownloads.length > 0 && !shouldWaitForCompletion) {
-      // Cancel active downloads and add them back to queue
-      for (const task of activeDownloads) {
-        if (task.request) {
-          task.request.destroy()
+    if (!shouldWaitForCompletion) {
+      for (const task of this.tasks.values()) {
+        if (task.status === 'downloading') {
+          // Passing the error triggers the 'Download aborted' catch branch in downloadTask
+          task.request?.destroy(new Error('Download aborted'))
         }
       }
     }
 
-    // If shouldWaitForCompletion is true, active downloads will complete naturally
-
-    this.isPaused = true
     this.emit(DownloadEvent.QUEUE_PAUSED)
   }
 
   public resumeQueue(): void {
     this.isPaused = false
+
+    if (this.currentMirrors.length && this.currentOptions) {
+      for (const task of this.tasks.values()) {
+        if (task.status === 'waiting') {
+          this.queue.add(() => this.downloadTask(task, this.currentMirrors, this.currentOptions!))
+        }
+      }
+    }
+
     this.emit(DownloadEvent.QUEUE_RESUMED)
   }
 
   public clearQueue(): void {
+    for (const task of this.tasks.values()) {
+      if (task.status === 'downloading') {
+        task.request?.destroy(new Error('Download aborted'))
+      }
+    }
     this.queue.clear()
     this.tasks.clear()
+    this.currentMirrors = []
+    this.currentOptions = null
     this.emit(DownloadEvent.QUEUE_CLEARED)
   }
 
@@ -630,10 +295,7 @@ class DownloadService extends EventEmitter {
     return this.queue.pending
   }
 
-  public getMirrorHealth(): Map<
-    string,
-    { success: number; failure: number; avgResponseTime: number }
-  > {
+  public getMirrorHealth(): Map<string, MirrorHealth> {
     return this.mirrorHealth
   }
 }


### PR DESCRIPTION
Bug fixes:
- Fix pause/resume: queue.clear() prevents task drain while paused; resumeQueue() re-adds all waiting tasks using stored currentMirrors/currentOptions; race condition guard re-adds aborted tasks if resume ran before abort settled
- Fix stop download: clearQueue() now destroys active HTTP requests before clearing; httpDownloader destroys response stream and writer on abort to stop file writes immediately

UI improvements:
- Add inline two-step stop confirmation (Stop -> confirm/cancel buttons)
- Show status message after queue completes (success/failed count) or is cancelled
- Disable pause button while confirming stop

Refactoring and cleanup:
- Modularize downloadService.ts into download/types.ts, fileUtils.ts, httpDownloader.ts
- Extract download settings persistence into useDownloadSettings composable
- Reuse validateDownloadPath from fileUtils in api.ts
- Consolidate .text-success/.text-error into main.css; remove duplicate Google Fonts imports
- Remove debug console.log statements throughout main process and components
- Add .eslintcache and .cursorindexingignore to .gitignore