### PR TITLE
Harden path validation and make downloads crash-safe.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ repomix-output.xml
 # Project notes
 notes.md
 example.json
+
+feedback/
+.branch-split-temp/

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,5 +1,5 @@
 import { app, shell, BrowserWindow, ipcMain, dialog } from 'electron'
-import { join } from 'path'
+import path from 'path'
 import { electronApp, optimizer, is } from '@electron-toolkit/utils'
 import icon from '../renderer/src/assets/logo.ico?asset'
 import { startServer, stopServer } from '../services/api'
@@ -9,6 +9,7 @@ import { APP_NAME, APP_ID, WINDOW_CONFIG } from '../config/constants'
 import DownloadService from '../services/downloadService'
 import { collectionService } from '../services/collection/collectionService'
 import CollectionSyncService from '../services/collection/collectionSyncService'
+import { safeJoinWithinRoot } from './pathGuards'
 
 function createWindow(): BrowserWindow {
   // Create the browser window.
@@ -22,7 +23,7 @@ function createWindow(): BrowserWindow {
     autoHideMenuBar: true,
     icon: icon,
     webPreferences: {
-      preload: join(__dirname, '../preload/index.js'),
+      preload: path.join(__dirname, '../preload/index.js'),
       contextIsolation: true,
       nodeIntegration: false,
       sandbox: false
@@ -47,7 +48,7 @@ function createWindow(): BrowserWindow {
   if (is.dev && process.env['ELECTRON_RENDERER_URL']) {
     mainWindow.loadURL(process.env['ELECTRON_RENDERER_URL'])
   } else {
-    mainWindow.loadFile(join(__dirname, '../renderer/index.html'))
+    mainWindow.loadFile(path.join(__dirname, '../renderer/index.html'))
   }
 
   return mainWindow
@@ -93,7 +94,11 @@ app.whenReady().then(() => {
 
   ipcMain.handle('check-subdir', async (_, dir: string, sub: string) => {
     try {
-      const subDirPath = join(dir, sub)
+      const safePath = safeJoinWithinRoot(dir, sub)
+      if (!safePath.valid || !safePath.joinedPath) {
+        return false
+      }
+      const subDirPath = safePath.joinedPath
       return fs.existsSync(subDirPath) && fs.statSync(subDirPath).isDirectory()
     } catch (error) {
       console.error('Error checking subdirectory:', error)
@@ -103,7 +108,11 @@ app.whenReady().then(() => {
 
   ipcMain.handle('check-file', async (_, dir: string, file: string) => {
     try {
-      const filePath = join(dir, file)
+      const safePath = safeJoinWithinRoot(dir, file)
+      if (!safePath.valid || !safePath.joinedPath) {
+        return false
+      }
+      const filePath = safePath.joinedPath
       return fs.existsSync(filePath) && fs.statSync(filePath).isFile()
     } catch (error) {
       console.error('Error checking file:', error)

--- a/src/main/pathGuards.spec.ts
+++ b/src/main/pathGuards.spec.ts
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict'
+import { safeJoinWithinRoot, validateRelativeSubPath } from './pathGuards'
+
+// Lightweight spec file for manual smoke testing.
+// Run with a TS runtime (e.g. tsx) when needed.
+export function runPathGuardSpecs(): void {
+  assert.equal(validateRelativeSubPath('Songs').valid, true)
+  assert.equal(validateRelativeSubPath('Songs\\Sub').valid, true)
+
+  assert.equal(validateRelativeSubPath('../Songs').valid, false)
+  assert.equal(validateRelativeSubPath('..\\Songs').valid, false)
+  assert.equal(validateRelativeSubPath('Songs/*').valid, false)
+  assert.equal(validateRelativeSubPath('Songs?.db').valid, false)
+
+  const okJoin = safeJoinWithinRoot('C:\\osu', 'Songs')
+  assert.equal(okJoin.valid, true)
+  assert.equal(Boolean(okJoin.joinedPath), true)
+
+  const escaped = safeJoinWithinRoot('C:\\osu', '..\\Windows')
+  assert.equal(escaped.valid, false)
+}

--- a/src/main/pathGuards.ts
+++ b/src/main/pathGuards.ts
@@ -1,0 +1,60 @@
+import path from 'path'
+
+const DISALLOWED_SUB_PATH_CHARS = /[*?<>|"]/
+
+function hasParentTraversal(input: string): boolean {
+  return input
+    .replace(/\\/g, '/')
+    .split('/')
+    .some((segment) => segment === '..')
+}
+
+export function validateRelativeSubPath(input: string): { valid: boolean; reason?: string } {
+  if (typeof input !== 'string') {
+    return { valid: false, reason: 'Sub path must be a string' }
+  }
+
+  const trimmed = input.trim()
+  if (!trimmed) {
+    return { valid: false, reason: 'Sub path is empty' }
+  }
+
+  if (DISALLOWED_SUB_PATH_CHARS.test(trimmed)) {
+    return { valid: false, reason: 'Sub path contains invalid wildcard characters' }
+  }
+
+  if (path.isAbsolute(trimmed)) {
+    return { valid: false, reason: 'Sub path must be relative' }
+  }
+
+  if (hasParentTraversal(trimmed)) {
+    return { valid: false, reason: 'Sub path traversal is not allowed' }
+  }
+
+  return { valid: true }
+}
+
+export function safeJoinWithinRoot(
+  rootDir: string,
+  subPath: string
+): { valid: boolean; joinedPath?: string } {
+  if (typeof rootDir !== 'string' || !rootDir.trim()) {
+    return { valid: false }
+  }
+
+  const validation = validateRelativeSubPath(subPath)
+  if (!validation.valid) {
+    return { valid: false }
+  }
+
+  const normalizedRoot = path.resolve(rootDir)
+  const targetPath = path.resolve(normalizedRoot, subPath)
+  const relativeToRoot = path.relative(normalizedRoot, targetPath)
+  const escapesRoot = relativeToRoot.startsWith('..') || path.isAbsolute(relativeToRoot)
+
+  if (escapesRoot) {
+    return { valid: false }
+  }
+
+  return { valid: true, joinedPath: targetPath }
+}

--- a/src/services/download/httpDownloader.ts
+++ b/src/services/download/httpDownloader.ts
@@ -52,8 +52,21 @@ export async function downloadFile(
     const startUrl = new URL(downloadUrl)
     const startTime = Date.now()
     let writer: fs.WriteStream | undefined
-    let filePath: string | undefined
+    let finalFilePath: string | undefined
+    let tempFilePath: string | undefined
     let currentResponse: http.IncomingMessage | undefined
+    let requestSettled = false
+
+    const failWithCleanup = (error: Error): void => {
+      if (requestSettled) return
+      requestSettled = true
+      currentResponse?.destroy()
+      writer?.destroy()
+      if (tempFilePath) {
+        fs.unlink(tempFilePath, () => {})
+      }
+      reject(error)
+    }
 
     const makeRequest = (targetUrl: URL, redirectCount = 0): void => {
       const protocol = targetUrl.protocol === 'http:' ? http : https
@@ -89,7 +102,7 @@ export async function downloadFile(
           }
 
           if (response.statusCode !== 200) {
-            reject(new Error(`Failed to download: ${response.statusCode}`))
+            failWithCleanup(new Error(`Failed to download: ${response.statusCode}`))
             return
           }
 
@@ -105,12 +118,13 @@ export async function downloadFile(
             }
           }
           fileName = sanitizeFileName(fileName)
-          filePath = path.join(downloadPath, fileName)
+          finalFilePath = path.join(downloadPath, fileName)
+          tempFilePath = `${finalFilePath}.part`
 
           task.fileName = fileName
           onProgress(task)
 
-          writer = fs.createWriteStream(filePath)
+          writer = fs.createWriteStream(tempFilePath)
           let downloadedBytes = 0
           let lastUpdate = startTime
           let lastBytes = 0
@@ -133,29 +147,44 @@ export async function downloadFile(
             }
           })
 
-          response.on('error', (err) => reject(err))
-          writer.on('error', (err) => reject(err))
+          response.on('error', (err) => failWithCleanup(err))
+          writer.on('error', (err) => failWithCleanup(err))
 
           response.pipe(writer)
 
           writer.on('finish', () => {
-            task.status = 'completed'
-            task.progress = 100
-            task.speed = 0
-            task.remainingTime = 0
-            task.filePath = filePath
-            resolve({ startTime })
+            if (!finalFilePath || !tempFilePath) {
+              failWithCleanup(new Error('Download finalize failed: missing target path'))
+              return
+            }
+            if (totalSize > 0 && downloadedBytes !== totalSize) {
+              failWithCleanup(
+                new Error(
+                  `Download incomplete: expected ${totalSize} bytes but received ${downloadedBytes} bytes`
+                )
+              )
+              return
+            }
+            fs.rename(tempFilePath, finalFilePath, (renameError) => {
+              if (renameError) {
+                failWithCleanup(renameError)
+                return
+              }
+              if (requestSettled) return
+              requestSettled = true
+              task.status = 'completed'
+              task.progress = 100
+              task.speed = 0
+              task.remainingTime = 0
+              task.filePath = finalFilePath
+              resolve({ startTime })
+            })
           })
         }
       )
 
       req.on('error', (error) => {
-        currentResponse?.destroy()
-        writer?.destroy()
-        if (filePath) {
-          fs.unlink(filePath, () => {})
-        }
-        reject(error)
+        failWithCleanup(error)
       })
 
       req.setTimeout(30000, () => {


### PR DESCRIPTION
Prevent IPC path traversal checks from escaping the selected root and write downloads through .part files so failed transfers clean up deterministically.