### PR TITLE
Add startup timing markers for dev diagnostics.

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,5 +1,5 @@
 import { app, shell, BrowserWindow, ipcMain, dialog } from 'electron'
-import { join } from 'path'
+import path from 'path'
 import { electronApp, optimizer, is } from '@electron-toolkit/utils'
 import icon from '../renderer/src/assets/logo.ico?asset'
 import { startServer, stopServer } from '../services/api'
@@ -9,9 +9,11 @@ import { APP_NAME, APP_ID, WINDOW_CONFIG } from '../config/constants'
 import DownloadService from '../services/downloadService'
 import { collectionService } from '../services/collection/collectionService'
 import CollectionSyncService from '../services/collection/collectionSyncService'
+import { startupMark } from '../services/startupTrace'
 
 function createWindow(): BrowserWindow {
   // Create the browser window.
+  startupMark('createWindow:start')
   const mainWindow = new BrowserWindow({
     title: APP_NAME,
     width: WINDOW_CONFIG.DEFAULT_WIDTH,
@@ -22,7 +24,7 @@ function createWindow(): BrowserWindow {
     autoHideMenuBar: true,
     icon: icon,
     webPreferences: {
-      preload: join(__dirname, '../preload/index.js'),
+      preload: path.join(__dirname, '../preload/index.js'),
       contextIsolation: true,
       nodeIntegration: false,
       sandbox: false
@@ -30,6 +32,7 @@ function createWindow(): BrowserWindow {
   })
 
   mainWindow.on('ready-to-show', () => {
+    startupMark('window:ready-to-show')
     mainWindow.show()
     // Open DevTools in development
     if (is.dev) {
@@ -45,11 +48,14 @@ function createWindow(): BrowserWindow {
   // HMR for renderer base on electron-vite cli.
   // Load the remote URL for development or the local html file for production.
   if (is.dev && process.env['ELECTRON_RENDERER_URL']) {
+    startupMark('window:loadURL', { url: process.env['ELECTRON_RENDERER_URL'] })
     mainWindow.loadURL(process.env['ELECTRON_RENDERER_URL'])
   } else {
-    mainWindow.loadFile(join(__dirname, '../renderer/index.html'))
+    startupMark('window:loadFile')
+    mainWindow.loadFile(path.join(__dirname, '../renderer/index.html'))
   }
 
+  startupMark('createWindow:end')
   return mainWindow
 }
 
@@ -57,6 +63,7 @@ function createWindow(): BrowserWindow {
 // initialization and is ready to create browser windows.
 // Some APIs can only be used after this event occurs.
 app.whenReady().then(() => {
+  startupMark('app:whenReady')
   // Set app user model id for windows
   electronApp.setAppUserModelId(APP_ID)
 
@@ -195,8 +202,10 @@ app.whenReady().then(() => {
   const startDeferredStartupTasks = (): void => {
     if (startupTasksStarted) return
     startupTasksStarted = true
+    startupMark('startupTasks:start')
     startServer()
     CollectionSyncService.getInstance().startBackgroundSync()
+    startupMark('startupTasks:scheduled')
   }
 
   mainWindow.once('ready-to-show', () => {

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -21,6 +21,7 @@ import { validateDownloadPath } from './download/fileUtils'
 import SyncManager from './database/syncManager'
 import type { SyncProgressEvent } from './database/types'
 import { DatabaseService } from './database/databaseService'
+import { startupMark } from './startupTrace'
 
 const app = express()
 const port = 3000
@@ -467,6 +468,7 @@ app.get('/api/database/sync/events', ((req: Request, res: Response) => {
 
 export function startServer(): void {
   try {
+    startupMark('api:startServer:begin')
     const mirrorService = BeatmapMirrorService.getInstance()
     mirrorService.startBackgroundHealthChecks()
     const downloadService = DownloadService.getInstance()
@@ -475,6 +477,7 @@ export function startServer(): void {
     void syncManager.runStartupSync()
 
     httpServer = app.listen(port, () => {
+      startupMark('api:startServer:listening', { port })
       console.log(`API server is running on port ${port}`)
       console.log(`Server URL: http://localhost:${port}`)
     })

--- a/src/services/database/syncManager.ts
+++ b/src/services/database/syncManager.ts
@@ -6,6 +6,7 @@ import { importFromLazerRealm } from './lazerImporter'
 import { realmService } from '../realmService'
 import { getOsuLazerPath, getOsuStablePath } from '../settingsStore'
 import type { DatabaseStatus, SyncProgressEvent, SyncSource } from './types'
+import { startupMark } from '../startupTrace'
 
 class SyncManager extends EventEmitter {
   private static instance: SyncManager
@@ -19,8 +20,11 @@ class SyncManager extends EventEmitter {
   }
 
   async runStartupSync(): Promise<void> {
+    startupMark('db:startupSync:begin')
     await this.syncSource('stable', false)
+    startupMark('db:startupSync:afterStable')
     await this.syncSource('lazer', false)
+    startupMark('db:startupSync:done')
   }
 
   async runManualSync(source: SyncSource | 'all', force = true): Promise<void> {
@@ -67,7 +71,9 @@ class SyncManager extends EventEmitter {
         lastFileMtime: stableLastMtime,
         currentFileMtime: stableCurrentMtime,
         beatmapCount: db.getBeatmapCountBySource('stable'),
-        isDirty: Boolean(stableCurrentMtime && stableLastMtime && stableCurrentMtime !== stableLastMtime)
+        isDirty: Boolean(
+          stableCurrentMtime && stableLastMtime && stableCurrentMtime !== stableLastMtime
+        )
       },
       lazer: {
         configured: Boolean(lazerConfiguredPath),
@@ -76,7 +82,9 @@ class SyncManager extends EventEmitter {
         lastFileMtime: lazerLastMtime,
         currentFileMtime: lazerCurrentMtime,
         beatmapCount: db.getBeatmapCountBySource('lazer'),
-        isDirty: Boolean(lazerCurrentMtime && lazerLastMtime && lazerCurrentMtime !== lazerLastMtime)
+        isDirty: Boolean(
+          lazerCurrentMtime && lazerLastMtime && lazerCurrentMtime !== lazerLastMtime
+        )
       }
     }
   }

--- a/src/services/startupTrace.ts
+++ b/src/services/startupTrace.ts
@@ -1,0 +1,12 @@
+import { is } from '@electron-toolkit/utils'
+
+const START_MS = Date.now()
+
+export function startupMark(label: string, extra?: Record<string, unknown>): void {
+  // Keep production logs clean by default.
+  if (!is.dev) return
+
+  const deltaMs = Date.now() - START_MS
+  const suffix = extra && Object.keys(extra).length > 0 ? ` ${JSON.stringify(extra)}` : ''
+  console.log(`[startup +${deltaMs}ms] ${label}${suffix}`)
+}


### PR DESCRIPTION
Record key Electron, API, and database startup checkpoints in development so slow launches can be traced without stepping through the startup flow manually.